### PR TITLE
Build fixes

### DIFF
--- a/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
+++ b/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
@@ -7,7 +7,7 @@ SRC_URI="git://github.com/guh/nymea-plugins.git;protocol=https;branch=master"
 SRCREV="${AUTOREV}"
 PV = "git${SRCPV}"
 
-DEPENDS += "nymead"
+DEPENDS += "nymead nymead-native"
 
 require recipes-qt/qt5/qt5.inc
 inherit qmake5

--- a/recipes-nymea/nymea-remoteproxy/nymea-remoteproxy_git.bb
+++ b/recipes-nymea/nymea-remoteproxy/nymea-remoteproxy_git.bb
@@ -7,7 +7,7 @@ SRC_URI="git://github.com/guh/nymea-remoteproxy.git;protocol=https;branch=master
 SRCREV="${AUTOREV}"
 PV = "git${SRCPV}"
 
-DEPENDS += "qtbase qtwebsockets"
+DEPENDS += "qtbase qtwebsockets ncurses"
 
 require recipes-qt/qt5/qt5.inc
 

--- a/recipes-nymea/nymead/nymead_git.bb
+++ b/recipes-nymea/nymead/nymead_git.bb
@@ -14,13 +14,25 @@ S = "${WORKDIR}/git"
 require recipes-qt/qt5/qt5.inc
 inherit update-rc.d qmake5
 
-DEPENDS += "qtbase qtwebsockets qtconnectivity nymea-mqtt nymea-remoteproxy avahi"
+BBCLASSEXTEND =+ "native"
+
+DEPENDS_class-target += "qtbase qtwebsockets qtconnectivity nymea-mqtt nymea-remoteproxy avahi"
+DEPENDS_class-native += "python"
 
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME = "nymead"
 #INISCRIPTS_PARAMS = "defaults 10"
 
-do_install_append() {
+do_configure_class-native() {
+}
+do_compile_class-native() {
+}
+do_install_class-native() {
+	install -d ${D}${bindir}
+	install -m 0755 ${S}/libnymea/plugin/nymea-generateplugininfo ${D}${bindir}
+}
+
+do_install_append_class-target() {
 	install -d ${D}${INIT_D_DIR}
 	install -m 0755 ${WORKDIR}/init ${D}${INIT_D_DIR}/nymead
 }


### PR DESCRIPTION
There are two build errors that need to be fixed at the moment.
* ncurses dependency was forgotten for nymea-remoteproxy.
* nymea-generateplugininfo was missing at build time for nymea-plugins which is provided by nymead at runtime (so we needed to add a native variant for nymead).