### PR TITLE
Do not put boblight in default PACKAGECONFIG if GPL-3.0 is in INCOMPATIBLE_LICENSE

### DIFF
--- a/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
+++ b/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
@@ -18,7 +18,7 @@ PACKAGECONFIG ?= "anel \
         aqi \
 	avahimonitor \
 	awattar \
-	boblight \
+	${@incompatible_license_contains('GPL-3.0', '', 'boblight', d)} \
         bose \
         coinmarketcap \
 	commandlauncher \


### PR DESCRIPTION
boblight is GPL-3.0 licensed and many people, for their own reasons,
don't want to deal with anything licensed under GPL-3.0.

With this change, boblight support will be compiled in by default *only*
if GPL-3.0 is not in INCOMPATIBLE_LICENSE.

This makes it easy to take the layer and just build without having to
add a bbappend for something so trivial.

Signed-off-by: Quentin Schulz <quentin.schulz@streamunlimited.com>