### PR TITLE
qt: qtbase-native: use _append openssl instead of _remove

### DIFF
--- a/recipes-qt/qt5/qtbase-native_git.bbappend
+++ b/recipes-qt/qt5/qtbase-native_git.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG_CONFARGS_remove = "-no-openssl"
+PACKAGECONFIG_CONFARGS_append = " -openssl"


### PR DESCRIPTION
_remove is definitive and can't be undone.

To be nicer to other layers, replace _remove -no-openssl by _append
-openssl. If the "same" option appears multiple times, only the last one
will be taken into account, so if someone wants to disable openssl they
still can _append -no-openssl to it (or use _remove but that's their
burden).

Signed-off-by: Quentin Schulz <quentin.schulz@streamunlimited.com>