### PR TITLE
recipes-qt: qt5: qtbase: remove gles2 PACKAGECONFIG

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bbappend
+++ b/recipes-qt/qt5/qtbase_git.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG += "sql-sqlite gles2 openssl"
+PACKAGECONFIG += "sql-sqlite openssl"


### PR DESCRIPTION
There does not seem to be a dependency on gles2 support in qtbase and
since it's a heavy dependency (need for opengl to DISTRO_FEATURES which
requires a full rebuild and many added packages), let's remove it for
now.

Signed-off-by: Quentin Schulz <quentin.schulz@streamunlimited.com>