### PR TITLE
support any meta-qt5 release branch for qtbase-native openssl support

### DIFF
--- a/recipes-qt/qt5/qtbase-native_git.bbappend
+++ b/recipes-qt/qt5/qtbase-native_git.bbappend
@@ -1,1 +1,3 @@
-PACKAGECONFIG_CONFARGS_append = " -openssl"
+PACKAGECONFIG[openssl] = "-openssl,-no-openssl,openssl"
+
+PACKAGECONFIG += "openssl"


### PR DESCRIPTION
In zeus and older release branches, PACKAGECONFIG_CONFARGS was directly
set within qtbase-native recipe without using PACKAGECONFIG mechanism
(or via QT_CONF_FLAGS).

However, the arguments selected by PACKAGECONFIG are appended after the
"manual" PACKAGECONFIG_CONFARGS_append are resolved, i.e. any
PACKAGECONFIG[foo] = "-foo,-no-foo,foo" with PACKAGECONFIG = "foo" will
put -foo at the very end of PACKAGECONFIG, even after our "manual"
PACKAGECONFIG_CONFARGS_append.

This means our PACKAGECONFIG_CONFARGS_append will be overridden by a
PACKAGECONFIG[openssl] = "-openssl,-no-openssl,openssl" line from any
bbappend or if the qtbase-native recipe has that line.

Starting from the dunfell branch, there is such a PACKAGECONFIG so we
need to take it into account.

Since PACKAGECONFIG mechanism works just fine on older releases, let's
just use this mechanism to support all meta-qt5 branches.

Fixes: 2fe92e56df5d "qt: qtbase-native: use _append openssl instead of _remove"

Signed-off-by: Quentin Schulz <quentin.schulz@streamunlimited.com>