### PR TITLE
conf: layer.conf: advertise thud support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,6 @@ BBFILE_COLLECTIONS += "meta-nymea"
 BBFILE_PATTERN_meta-nymea := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-nymea = "10"
 
+LAYERSERIES_COMPAT_meta-nymea = "thud"
+
 LICENSE_PATH += "${LAYERDIR}/licenses"


### PR DESCRIPTION
meta-nymea is being used currently on Yocto thud release and it works
just fine so let's advertise meta-nymea works with it.

Signed-off-by: Quentin Schulz <quentin.schulz@streamunlimited.com>