### PR TITLE
recipes-nymea: bump recipes to 0.25.1 release

### DIFF
--- a/recipes-nymea/libnymea-networkmanager/libnymea-networkmanager_git.bb
+++ b/recipes-nymea/libnymea-networkmanager/libnymea-networkmanager_git.bb
@@ -4,9 +4,9 @@ LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
 LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://libnymea-networkmanager/networkmanager.h;endline=26;md5=c334ac0bc498bb8b53007125752e1471"
 
-SRC_URI="git://github.com/nymea/libnymea-networkmanager.git;protocol=https;branch=experimental-silo"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+SRC_URI="git://github.com/nymea/libnymea-networkmanager.git;protocol=https;branch=master"
+# Release: 0.4.2
+SRCREV="cd5bd22b23178224bd265ece649770d1fedcb1c1"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase qtconnectivity"

--- a/recipes-nymea/nymea-app/nymea-app_git.bb
+++ b/recipes-nymea/nymea-app/nymea-app_git.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM="file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SRC_URI="git://github.com/nymea/nymea-app.git;protocol=https;branch=master"
 
-# Release: 1.0.244
-SRCREV="0c06a1208d9461d0459e04f34a49c2959e64ce55"
+# Release: 1.0.275
+SRCREV="ef40e6e642d315d0b59bd7c43cde9ea1cc079822"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase nymead nymea-remoteproxy qtcharts qtquickcontrols2 qtsvg"

--- a/recipes-nymea/nymea-mqtt/nymea-mqtt_git.bb
+++ b/recipes-nymea/nymea-mqtt/nymea-mqtt_git.bb
@@ -6,9 +6,9 @@ LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://server/main.cpp;endline=26;md5=6ad94e4fdc53ed04d6af1e48393a1d49 \
                   file://libnymea-mqtt/mqtt.h;endline=26;md5=8145dc10125aa2f5603e524b7245a070"
 
-SRC_URI="git://github.com/nymea/nymea-mqtt.git;protocol=https;branch=experimental-silo"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+SRC_URI="git://github.com/nymea/nymea-mqtt.git;protocol=https;branch=master"
+# Release: 0.1.6
+SRCREV="a617e504fef5c8ec5ac94da5050bfd14e377dea5"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase"

--- a/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
+++ b/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
@@ -3,9 +3,9 @@ DESCRIPTION = "nymea-plugins"
 LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
 LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404"
 
-SRC_URI="git://github.com/nymea/nymea-plugins.git;protocol=https;branch=experimental-silo"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+SRC_URI="git://github.com/nymea/nymea-plugins.git;protocol=https;branch=master"
+# Release: 0.25.0
+SRCREV="cdff51655fe5c5a90ed9c2c67896cc904ecb122f"
 PV = "git${SRCPV}"
 
 DEPENDS += "nymead nymead-native"

--- a/recipes-nymea/nymea-remoteproxy/nymea-remoteproxy_git.bb
+++ b/recipes-nymea/nymea-remoteproxy/nymea-remoteproxy_git.bb
@@ -6,9 +6,9 @@ LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://server/main.cpp;endline=26;md5=6ad94e4fdc53ed04d6af1e48393a1d49 \
                   file://libnymea-remoteproxyclient/proxyconnection.h;endline=26;md5=8145dc10125aa2f5603e524b7245a070"
 
-SRC_URI="git://github.com/nymea/nymea-remoteproxy.git;protocol=https;branch=experimental-silo"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+SRC_URI="git://github.com/nymea/nymea-remoteproxy.git;protocol=https;branch=master"
+# Release: 0.1.11
+SRCREV="a74b07a2f4d44ba1fc1b1a4a8b56b9cf5db1384f"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase qtwebsockets ncurses"

--- a/recipes-nymea/nymea-zeroconf-plugin-avahi/nymea-zeroconf-plugin-avahi_git.bb
+++ b/recipes-nymea/nymea-zeroconf-plugin-avahi/nymea-zeroconf-plugin-avahi_git.bb
@@ -4,8 +4,8 @@ LICENSE = "LGPLv2"
 LIC_FILES_CHKSUM="file://LICENSE;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI="git://github.com/nymea/nymea-zeroconf-plugin-avahi.git;protocol=https"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+# Release: 0.9
+SRCREV="15dbe87f15e11471f6f0d985ae25ce42678b3ad6"
 PV = "git${SRCPV}"
 
 DEPENDS += "nymead avahi"

--- a/recipes-nymea/nymea-zeroconf-plugin-dnssd/nymea-zeroconf-plugin-dnssd_git.bb
+++ b/recipes-nymea/nymea-zeroconf-plugin-dnssd/nymea-zeroconf-plugin-dnssd_git.bb
@@ -4,9 +4,9 @@ LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
 LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://platformzeroconfcontrollerdnssd.cpp;endline=29;md5=02466154ec3d6f169e687813994f869a"
 
-SRC_URI="git://github.com/nymea/nymea-zeroconf-plugin-dnssd.git;protocol=https;branch=experimental-silo"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+SRC_URI="git://github.com/nymea/nymea-zeroconf-plugin-dnssd.git;protocol=https;branch=master"
+# Release: 0.5
+SRCREV="119cb3918621031f9681e6e8a25b4291e59b72b6"
 PV = "git${SRCPV}"
 
 DEPENDS += "nymead mdns"

--- a/recipes-nymea/nymea-zigbee/nymea-zigbee_git.bb
+++ b/recipes-nymea/nymea-zigbee/nymea-zigbee_git.bb
@@ -3,9 +3,9 @@ DESCRIPTION = "nymea-zigbee package"
 LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
 LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404"
 
-SRC_URI="git://github.com/nymea/nymea-zigbee.git;protocol=https;branch=experimental-silo"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+SRC_URI="git://github.com/nymea/nymea-zigbee.git;protocol=https;branch=master"
+# Release: 0.1.0
+SRCREV="90eb82401836f71aa78d25697b330c2cbc58eead"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase qtserialport eudev"

--- a/recipes-nymea/nymead/nymead_git.bb
+++ b/recipes-nymea/nymead/nymead_git.bb
@@ -6,11 +6,11 @@ LIC_FILES_CHKSUM="file://LICENSE.GPL3;md5=1ebbd3e34237af26da5dc08a4e440464 \
                   file://server/main.cpp;endline=26;md5=8a20c67e762ff092bbb93325ead286dc \
                   file://libnymea/libnymea.h;endline=26;md5=c334ac0bc498bb8b53007125752e1471"
 
-SRC_URI="git://github.com/nymea/nymea.git;protocol=https;branch=experimental-silo \
+SRC_URI="git://github.com/nymea/nymea.git;protocol=https;branch=master \
 	file://init \
 	"
-# Release: experimental-silo
-SRCREV="${AUTOREV}"
+# Release: 0.25.1
+SRCREV="493b211eec1a26e5ef1cae9703a67f366468ed08"
 PV = "git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
No build was run, it is only a bump done by running `updatesrcrevs.sh
master`.

Signed-off-by: Quentin Schulz <quentin.schulz@streamunlimited.com>