### PR TITLE
layer.conf: declare compatibility with dunfell

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,6 +9,6 @@ BBFILE_COLLECTIONS += "meta-nymea"
 BBFILE_PATTERN_meta-nymea := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-nymea = "10"
 
-LAYERSERIES_COMPAT_meta-nymea = "thud"
+LAYERSERIES_COMPAT_meta-nymea = "thud dunfell"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"


### PR DESCRIPTION
The layer works well in yocto dunfell, marking it compatible.

Signed-off-by: Andriy Danylovskyy <andriy.danylovskyy@streamunlimited.com>