### PR TITLE
Pump to 1.0 release

### DIFF
--- a/recipes-nymea/libnymea-networkmanager/libnymea-networkmanager_git.bb
+++ b/recipes-nymea/libnymea-networkmanager/libnymea-networkmanager_git.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://libnymea-networkmanager/networkmanager.h;endline=26;md5=c334ac0bc498bb8b53007125752e1471"
 
 SRC_URI="git://github.com/nymea/libnymea-networkmanager.git;protocol=https;branch=master"
-# Release: 0.5.1
-SRCREV="eff82a3a7e859c2b90c1688945d797d6e205a2ca"
+# Release: 1.0.0
+SRCREV="69909b8652eaea3c60c59b8a9ce465ae647959e4"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase qtconnectivity"

--- a/recipes-nymea/nymea-app/nymea-app_git.bb
+++ b/recipes-nymea/nymea-app/nymea-app_git.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM="file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SRC_URI="git://github.com/nymea/nymea-app.git;protocol=https;branch=master"
 
-# Release: 1.0.345
-SRCREV="6da24549675391ec32881142f2c92bdea49bc42f"
+# Release: 1.0.448
+SRCREV="c94509c88625f71e2565dd29467bca621c23f530"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase nymead nymea-remoteproxy qtcharts qtquickcontrols2 qtsvg"

--- a/recipes-nymea/nymea-gpio/nymea-gpio.bb
+++ b/recipes-nymea/nymea-gpio/nymea-gpio.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "nymea-gpio package"
+
+LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
+LICENSE_${PN}-utils = "LICENSE.GPL3 | NYMEA-COMMERCIAL"
+LIC_FILES_CHKSUM="file://LICENSE.LPGL3;md5=3000208d539ec061b899bce1d9ce9404 \
+                  file://LICENSE.GPL3;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+SRC_URI="git://github.com/nymea/nymea-gpio.git;protocol=https;branch=master"
+# Release: 1.0.0
+SRCREV="83b913ae3aec7b566b39376ceb0bc9de575a7065"
+PV = "git${SRCPV}"
+
+DEPENDS += "qtbase"
+
+S = "${WORKDIR}/git"
+
+PACKAGES += "${PN}-utils"
+
+FILES_${PN} = "${libdir}/*.so.*"
+FILES_${PN}-utils = "${bindir}/*"
+
+inherit qmake5

--- a/recipes-nymea/nymea-mqtt/nymea-mqtt_git.bb
+++ b/recipes-nymea/nymea-mqtt/nymea-mqtt_git.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://libnymea-mqtt/mqtt.h;endline=26;md5=8145dc10125aa2f5603e524b7245a070"
 
 SRC_URI="git://github.com/nymea/nymea-mqtt.git;protocol=https;branch=master"
-# Release: 0.1.9
-SRCREV="b856c584f82d48a6fa9f0951e89e8957d831ebb5"
+# Release: 1.0.0
+SRCREV="c67071ff09a844abd4f752c91eda8a425ab50096"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase"

--- a/recipes-nymea/nymea-plugins-zigbee/nymea-plugins-zigbee_git.bb
+++ b/recipes-nymea/nymea-plugins-zigbee/nymea-plugins-zigbee_git.bb
@@ -1,0 +1,37 @@
+DESCRIPTION = "nymea-plugins-zigbee"
+
+LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
+LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404"
+
+SRC_URI="git://github.com/nymea/nymea-plugins-zigbee.git;protocol=https;branch=master"
+# Release: 1.0.0
+SRCREV="75314cf373476ee20a1545b834d4c66acdb6d851"
+PV = "git${SRCPV}"
+
+DEPENDS += "nymead nymead-native"
+
+inherit qmake5
+
+S = "${WORKDIR}/git"
+
+# PACKAGECONFIG options should **never** set WITH_PLUGINS in the leftmost argument
+# PACKAGECONFIG[zigbeelumi] = ", WITHOUT_PLUGINS+=zigbeelumi"
+
+EXTRA_QMAKEVARS_PRE += "${PACKAGECONFIG_CONFARGS}"
+
+# One can find all available plugins by running oe-pkgdata-util list-pkgs nymea-plugins after having bitbake'd nymea-plugins
+PACKAGESPLITFUNCS_prepend = " split_nymea_plugins_packages "
+
+python split_nymea_plugins_packages() {
+    nymea_libdir = d.expand('${libdir}/nymea/plugins/')
+    plugins = do_split_packages(d, nymea_libdir, r'^libnymea_integrationplugin(.*)\.so\.*', 'nymea-plugin-%s', 'Nymea integration plugin for %s', extra_depends='')
+
+    # Make nymea-plugins-zigbee a meta package which RDEPENDS on all available nymea-plugin-zigbee*
+    d.setVar('RDEPENDS_' + d.getVar('PN'), ' '.join(plugins))
+}
+
+ALLOW_EMPTY_${PN} = "1"
+FILES_${PN} = ""
+
+# Dynamically generate packages for all enabled plugins
+PACKAGES_DYNAMIC = "^nymea-plugin-zigbee.*"

--- a/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
+++ b/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
@@ -4,8 +4,8 @@ LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
 LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404"
 
 SRC_URI="git://github.com/nymea/nymea-plugins.git;protocol=https;branch=master"
-# Release: 0.28.1
-SRCREV="f966532b57b70b57166d9e15b3bc970d28a8198f"
+# Release: 1.0.0
+SRCREV="750afb77f98cb0c41c91948b6b0395d24ce6b914"
 PV = "git${SRCPV}"
 
 DEPENDS += "nymead nymead-native"

--- a/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
+++ b/recipes-nymea/nymea-plugins/nymea-plugins_git.bb
@@ -32,7 +32,7 @@ PACKAGECONFIG[onewire] = ", WITHOUT_PLUGINS+=onewire, owfs"
 PACKAGECONFIG[serialportcommander] = ", WITHOUT_PLUGINS+=serialportcommander, qtserialport"
 PACKAGECONFIG[usbrelay] = ", WITHOUT_PLUGINS+=usbreleay, hidapi"
 
-EXTRA_QMAKEVARS_PRE += "CONFIG+=selection ${PACKAGECONFIG_CONFARGS}"
+EXTRA_QMAKEVARS_PRE += "${PACKAGECONFIG_CONFARGS}"
 
 # One can find all available plugins by running oe-pkgdata-util list-pkgs nymea-plugins after having bitbake'd nymea-plugins
 PACKAGESPLITFUNCS_prepend = " split_nymea_plugins_packages "
@@ -49,4 +49,4 @@ ALLOW_EMPTY_${PN} = "1"
 FILES_${PN} = ""
 
 # Dynamically generate packages for all enabled plugins
-PACKAGES_DYNAMIC = "^nymea-plugin-.*"
+PACKAGES_DYNAMIC = "^nymea-plugin-(?!zigbee).*"

--- a/recipes-nymea/nymea-remoteproxy/nymea-remoteproxy_git.bb
+++ b/recipes-nymea/nymea-remoteproxy/nymea-remoteproxy_git.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://libnymea-remoteproxyclient/proxyconnection.h;endline=26;md5=8145dc10125aa2f5603e524b7245a070"
 
 SRC_URI="git://github.com/nymea/nymea-remoteproxy.git;protocol=https;branch=master"
-# Release: 0.1.14
-SRCREV="f5b5bb030dfd7cebcc1432be7d2411ac0f3ad7a8"
+# Release: 1.0.0
+SRCREV="6c6013665f21cc8ef526cd4447df95d79c06d68e"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase qtwebsockets ncurses"

--- a/recipes-nymea/nymea-zeroconf-plugin-avahi/nymea-zeroconf-plugin-avahi_git.bb
+++ b/recipes-nymea/nymea-zeroconf-plugin-avahi/nymea-zeroconf-plugin-avahi_git.bb
@@ -8,8 +8,8 @@ LIC_FILES_CHKSUM=" \
                   "
 
 SRC_URI="git://github.com/nymea/nymea-zeroconf-plugin-avahi.git;protocol=https"
-# Release: 0.10
-SRCREV="ab13646caccb38a8d497b8d05f8e410527a6574d"
+# Release: 1.0.0
+SRCREV="6d564faa75fd948a88836b1b7c0bf948925dde8d"
 PV = "git${SRCPV}"
 
 DEPENDS += "nymead avahi"

--- a/recipes-nymea/nymea-zeroconf-plugin-dnssd/nymea-zeroconf-plugin-dnssd_git.bb
+++ b/recipes-nymea/nymea-zeroconf-plugin-dnssd/nymea-zeroconf-plugin-dnssd_git.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404 \
                   file://platformzeroconfcontrollerdnssd.cpp;endline=29;md5=02466154ec3d6f169e687813994f869a"
 
 SRC_URI="git://github.com/nymea/nymea-zeroconf-plugin-dnssd.git;protocol=https;branch=master"
-# Release: 0.6
-SRCREV="2a9aab967625207cc5630fdef0d344f03a3c5d59"
+# Release: 1.0.0
+SRCREV="42bee0f5b875c24851db8e3394982e02fc0d2c09"
 PV = "git${SRCPV}"
 
 DEPENDS += "nymead mdns"

--- a/recipes-nymea/nymea-zigbee/files/0001-Make-qca-optional-only-required-for-TI-backend.patch
+++ b/recipes-nymea/nymea-zigbee/files/0001-Make-qca-optional-only-required-for-TI-backend.patch
@@ -1,0 +1,55 @@
+From 932a4bcd22a529c9437f1ea12a445520ab75898b Mon Sep 17 00:00:00 2001
+From: Lukas Pfeifhofer <lukas.pfeifhofer@streamunlimited.com>
+Date: Mon, 7 Feb 2022 10:51:34 +0100
+Subject: [PATCH 1/1] Make qca optional, only required for TI backend.
+
+---
+ libnymea-zigbee/backends/ti/zigbeenetworkti.cpp | 4 +++-
+ libnymea-zigbee/libnymea-zigbee.pro             | 8 +++++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/libnymea-zigbee/backends/ti/zigbeenetworkti.cpp b/libnymea-zigbee/backends/ti/zigbeenetworkti.cpp
+index dc2b93c..285ec1e 100644
+--- a/libnymea-zigbee/backends/ti/zigbeenetworkti.cpp
++++ b/libnymea-zigbee/backends/ti/zigbeenetworkti.cpp
+@@ -32,7 +32,9 @@
+ #include "zigbeenetworkdatabase.h"
+ 
+ #include <QDataStream>
++#ifndef DISABLE_QCA
+ #include <QtCrypto>
++#endif
+ 
+ ZigbeeNetworkTi::ZigbeeNetworkTi(const QUuid &networkUuid, QObject *parent) :
+     ZigbeeNetwork(networkUuid, parent)
+@@ -290,7 +292,7 @@ void ZigbeeNetworkTi::processGreenPowerFrame(const Zigbee::ApsdeDataIndication &
+ 
+ QByteArray ZigbeeNetworkTi::encryptSecurityKey(quint32 sourceId, const QByteArray &securityKey)
+ {
+-#if (QCA_VERSION >= QCA_VERSION_CHECK(2, 2, 0))
++#ifndef DISABLE_QCA
+     QByteArray sourceIdArray;
+     sourceIdArray.append(static_cast<quint8>(sourceId & 0x000000ff));
+     sourceIdArray.append(static_cast<quint8>((sourceId & 0x0000ff00) >> 8));
+diff --git a/libnymea-zigbee/libnymea-zigbee.pro b/libnymea-zigbee/libnymea-zigbee.pro
+index 7f701c4..d3fd6f4 100644
+--- a/libnymea-zigbee/libnymea-zigbee.pro
++++ b/libnymea-zigbee/libnymea-zigbee.pro
+@@ -12,7 +12,13 @@ packagesExist(libudev) {
+     DEFINES += DISABLE_UDEV
+ }
+ 
+-PKGCONFIG += qca2-qt5
++packagesExist(qca2-qt5) {
++    message(Build with libqca2 support)
++    PKGCONFIG += qca2-qt5
++} else {
++    message(Build without libqca2 support)
++    DEFINES += DISABLE_QCA
++}
+ 
+ SOURCES += \
+     backends/deconz/interface/zigbeeinterfacedeconz.cpp \
+-- 
+2.25.1
+

--- a/recipes-nymea/nymea-zigbee/nymea-zigbee_git.bb
+++ b/recipes-nymea/nymea-zigbee/nymea-zigbee_git.bb
@@ -8,6 +8,11 @@ SRC_URI="git://github.com/nymea/nymea-zigbee.git;protocol=https;branch=master"
 SRCREV="187278cf7cce597c3cdac7f0d71d0695e5f48186"
 PV = "git${SRCPV}"
 
+# Make dependency on qca2-qt5 optional if we do not want to support TI Zigbee backend
+SRC_URI += "\
+		file://0001-Make-qca-optional-only-required-for-TI-backend.patch \
+	"
+
 DEPENDS += "qtbase qtserialport eudev"
 
 S = "${WORKDIR}/git"

--- a/recipes-nymea/nymea-zigbee/nymea-zigbee_git.bb
+++ b/recipes-nymea/nymea-zigbee/nymea-zigbee_git.bb
@@ -4,8 +4,8 @@ LICENSE = "LGPL-3.0 | NYMEA-COMMERCIAL"
 LIC_FILES_CHKSUM="file://LICENSE.LGPL3;md5=3000208d539ec061b899bce1d9ce9404"
 
 SRC_URI="git://github.com/nymea/nymea-zigbee.git;protocol=https;branch=master"
-# Release: 0.1.3
-SRCREV="c5d9b119af707ea66af5545754afe4c560f518b7"
+# Release: 1.0.0
+SRCREV="187278cf7cce597c3cdac7f0d71d0695e5f48186"
 PV = "git${SRCPV}"
 
 DEPENDS += "qtbase qtserialport eudev"

--- a/recipes-nymea/nymead/nymead_git.bb
+++ b/recipes-nymea/nymead/nymead_git.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM="file://LICENSE.GPL3;md5=1ebbd3e34237af26da5dc08a4e440464 \
 SRC_URI="git://github.com/nymea/nymea.git;protocol=https;branch=master \
 	file://init \
 	"
-# Release: 0.28.1
-SRCREV="685450fdb36fcb2b81d1d5d095ce98c3fccf8a54"
+# Release: 1.0.0
+SRCREV="bb03d17c799ff4e41920f094b166e8da8009e35d"
 PV = "git${SRCPV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-nymea/nymead/nymead_git.bb
+++ b/recipes-nymea/nymead/nymead_git.bb
@@ -20,7 +20,7 @@ inherit update-rc.d qmake5
 BBCLASSEXTEND += "native"
 
 DEPENDS = "qtbase"
-DEPENDS_append_class-target = " qtwebsockets qtconnectivity qtdeclarative nymea-remoteproxy libnymea-networkmanager nymea-mqtt nymea-zigbee"
+DEPENDS_append_class-target = " qtwebsockets qtconnectivity qtdeclarative nymea-gpio nymea-remoteproxy libnymea-networkmanager nymea-mqtt nymea-zigbee"
 
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME = "nymead"

--- a/recipes-nymea/nymead/nymead_git.bb
+++ b/recipes-nymea/nymead/nymead_git.bb
@@ -22,6 +22,9 @@ BBCLASSEXTEND += "native"
 DEPENDS = "qtbase"
 DEPENDS_append_class-target = " qtwebsockets qtconnectivity qtdeclarative nymea-gpio nymea-remoteproxy libnymea-networkmanager nymea-mqtt nymea-zigbee"
 
+# dpkg-parsechangelog
+DEPENDS += "dpkg-native"
+
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME = "nymead"
 #INISCRIPTS_PARAMS = "defaults 10"


### PR DESCRIPTION
These commits align the meta layer with the latest release.

- Fixed missing version string (because of missing dpkg-parsechangelog during the build process)
- Extracted zigbee plugins into its own recipe.
- https://github.com/doctorseus/meta-nymea/commit/d4fcc25a2f04b054c6a030007c54e1ed5dfb7cec should go to upstream in a later release I believe.