### PR TITLE
Introduce packagegroups for nymea

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -2,8 +2,11 @@
 # to BBPATH as we want to override archiver.bbclass
 BBPATH := "${LAYERDIR}:${BBPATH}"
 
-# We have a recipes directory, add to BBFILES
-BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
+# We have recipes-* and packagegroups directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend \
+            ${LAYERDIR}/packagegroups/*.bb \
+            ${LAYERDIR}/packagegroups/*.bbappend"
 
 BBFILE_COLLECTIONS += "nymea"
 BBFILE_PATTERN_nymea := "^${LAYERDIR}/"

--- a/packagegroups/packagegroup-nymea-energy.bb
+++ b/packagegroups/packagegroup-nymea-energy.bb
@@ -1,0 +1,40 @@
+SUMMARY = "nymea energy system"
+DESCRIPTION = "Default packages for running a nymea energy system."
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    nymead \
+    nymea-data \
+    nymea-experience-plugin-energy \
+    nymea-system-plugin-systemd \
+    nymea-zeroconf-plugin-avahi \
+    nymea-plugin-common-easee \
+    nymea-plugin-common-evbox \
+    nymea-plugin-common-everest \
+    nymea-plugin-common-fronius \
+    nymea-plugin-common-keba \
+    nymea-plugin-common-mecelectronics \
+    nymea-plugin-common-mystrom \
+    nymea-plugin-common-openweathermap \
+    nymea-plugin-common-powerfox \
+    nymea-plugin-common-shelly \
+    nymea-plugin-generic-genericcar \
+    nymea-plugin-modbus-bgetech \
+    nymea-plugin-modbus-huawei \
+    nymea-plugin-modbus-inepro \
+    nymea-plugin-modbus-inro \
+    nymea-plugin-modbus-kostal \
+    nymea-plugin-modbus-mennekes \
+    nymea-plugin-modbus-pcelectric \
+    nymea-plugin-modbus-phoenixconnect \
+    nymea-plugin-modbus-schrack \
+    nymea-plugin-modbus-sma \
+    nymea-plugin-modbus-solax \
+    nymea-plugin-modbus-sungrow \
+    nymea-plugin-modbus-sunspec \
+    nymea-plugin-modbus-vestel \
+    nymea-plugin-modbus-wattsonic \
+    nymea-plugin-modbus-webasto \
+"

--- a/packagegroups/packagegroup-nymea.bb
+++ b/packagegroups/packagegroup-nymea.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Generic nymea installation with all plugins and InfluxDB"
+DESCRIPTION = "Installs nymea with a default nymea plugin set."
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    nymead \
+    nymea-data \
+    nymea-plugins \
+    nymea-plugins-modbus \
+    nymea-experience-plugin-energy \
+    nymea-system-plugin-systemd \
+    nymea-zeroconf-plugin-avahi \
+    influxdb \
+"

--- a/recipes-image/images/yocto-nymea-image.bb
+++ b/recipes-image/images/yocto-nymea-image.bb
@@ -3,16 +3,7 @@ DESCRIPTION = "Yocto image for nymea"
 IMAGE_FEATURES += "ssh-server-dropbear"
 
 CORE_IMAGE_EXTRA_INSTALL = " \
-	nymead  \
-        nymea-plugins \
-        nymea-plugins-modbus \
-        nymea-experience-plugin-energy \
-        nymea-system-plugin-systemd \
-        nymea-zeroconf-plugin-avahi \
-	influxdb \
-	avahi-daemon \
-	libavahi-client \
-	"
+    packagegroup-nymea \
+"
 
 inherit core-image
- 


### PR DESCRIPTION
This PR introduces two package groups for nymea:
- a generic one with a common/universal package set
- one for nymea energy tailored use-case: EVSE charging with PV
